### PR TITLE
Fix get_active_producers in eosiolib #112

### DIFF
--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -49,10 +49,10 @@ namespace eosio {
    }
 
    std::vector<name> get_active_producers() {
-      auto prod_cnt = get_active_producers(nullptr, 0)/8;
-     std::vector<name> active_prods(prod_cnt);
-     get_active_producers((uint64_t*)active_prods.data(), active_prods.size());
-     return active_prods;
+      auto buffer_size = get_active_producers(nullptr, 0);
+      std::vector<name> active_prods(buffer_size / sizeof(uint64_t));
+      get_active_producers((uint64_t*)active_prods.data(), buffer_size);
+      return active_prods;
    }
 
 } // namespace eosio


### PR DESCRIPTION
Resolve #112:
- Fixed bug what `get_active_producers` was returning wrong vector because of wrong buffer size used.
- Used `sizeof(uint64_t)` instead of hardcoded number 8.
