### PR TITLE
Fix _Bool in codegen dispatchers #141

### DIFF
--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -256,12 +256,12 @@ namespace eosio { namespace cdt {
                   clang::LangOptions lang_opts;
                   lang_opts.CPlusPlus = true;
                   clang::PrintingPolicy policy(lang_opts);
+                  policy.Bool = 1;
                   auto qt = param->getOriginalType().getNonReferenceType();
                   qt.removeLocalConst();
                   qt.removeLocalVolatile();
                   qt.removeLocalRestrict();
                   std::string tn = clang::TypeName::getFullyQualifiedName(qt, *(cg.ast_context), policy);
-                  tn = tn == "_Bool" ? "bool" : tn; // TODO look out for more of these oddities
                   ss << tn << " arg" << i << "; ds >> arg" << i << ";\n";
                   i++;
                }


### PR DESCRIPTION
Resolve #141 :
In generating action- and notify-dispatchers fixed all _Bool (which not compiles) to treat as bool. 
Previous solution was handling properly only raw bool args like this:
```
[[eosio::action]] void hello(bool arg);
```
but not:
```
 [[eosio::action]] void hello(optional<bool> arg);
```
New way is simply and more correct.

**Note:** we will use `codegen.hpp` to automatically generate `EOSIO_DISPATCH`-es and transfer-, unstaking-, another dispatchers in CyberWay contracts, on base of `[[eosio::action]]` and `[[eosio::on_notify]]` attributes. instead of defining macros with list of actions to dispatch with potential FC_REFLECT (@afalaleev I can't forgot it)))) ) effect