### PR TITLE
 Recursive [[eosio::ignore]] #159 

### DIFF
--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -316,7 +316,7 @@ namespace eosio { namespace cdt {
             return;
          evaluated.insert(t.getTypePtr());
          auto type = get_ignored_type(t);
-         if (!is_builtin_type(translate_type(type))) {
+         if (!is_builtin_type(translate_type(type, false))) {
             if (is_aliasing(type))
                add_typedef(type);
             else if (is_template_specialization(type, {"vector", "set", "deque", "list", "optional", "binary_extension", "ignore"})) {


### PR DESCRIPTION
Resolves #159.
Improves `[[eosio::ignore]]`:
- Supports types having alias, or wrapped in `vector<Type>`, `variant<Type>` and etc.
- Supports ignoring of few "nested"-wrapped types.
- Refactored `get_ignored_type` method.

### Example of new attribute usage:
```
struct param {
    int value;
};

template<typename T>
struct [[eosio::ignore]] param_wrapper {
    int some_stuff;
};

...
[[eosio::action]] void setparams(vector<param_wrapper<param>> p);
```
Will result in:
```
{
    "name": "param",
    "fields":[
        "name": "value",
        "type: "int32"
    ]
},
{
    "name": "setparams",
    "fields":[
        "name": "p",
        "type: "param[]"
    ]
}
```

#### And even nested!
```
template<typename T>
struct [[eosio::ignore]] param_wrapper {
    int some_stuff;
};

template<typename T>
struct [[eosio::ignore]] second_wrapper {
    int some_stuff;
};

template<typename T>
struct [[eosio::ignore]] third_wrapper {
    int some_stuff;
};

[[eosio::action]] void setparams(vector<third_wrapper<second_wrapper<param_wrapper<param>>>> p);
```
Still results in:
```
{
    "name": "param",
    "fields":[
        "name": "value",
        "type: "int32"
    ]
},
{
    "name": "setparams",
    "fields":[
        "name": "p",
        "type: "param[]"
    ]
}
```