### PR TITLE
Return from abidiff non-zero exit code when ABI diffs #167

### DIFF
--- a/tools/abidiff/cyberway-abidiff.cpp.in
+++ b/tools/abidiff/cyberway-abidiff.cpp.in
@@ -74,13 +74,15 @@ class abidiff {
          return (std::stod(ver.substr(ver.size()-3))*10);
       }
 
-      void diff_version() {
+      unsigned diff_version() {
          if (get_version(abi_1) != get_version(abi_2)) {
             std::cout << "< version\n\t";
             std::cout << abi_1["version"] << "\n";
             std::cout << "> version\n\t";
             std::cout << abi_2["version"] << "\n";
+            return 1;
          }
+         return 0;
       }
       
       void print_struct(const ojson& abi, int index, char direction) {
@@ -96,7 +98,8 @@ class abidiff {
          return type;
       }
 
-      void find_structs(const ojson& abi1, const ojson& abi2, char direction) {
+      unsigned find_structs(const ojson& abi1, const ojson& abi2, char direction) {
+         unsigned differences = 0;
          for ( int i=0; i < abi1["structs"].size(); i++ ) {
             bool found = false;
             for ( int j=0; j < abi2["structs"].size(); j++ ) {
@@ -116,9 +119,12 @@ class abidiff {
                   }
                }
             }
-            if (!found)
+            if (!found) {
+               ++differences;
                print_struct(abi1, i, direction);
+            }
          }
+         return differences;
       }
 
       void print_type(const ojson& abi, int index, char direction) {
@@ -126,7 +132,8 @@ class abidiff {
          std::cout << pretty_print(abi["types"].at(index)) << "\n";
       }
 
-      void find_types(const ojson& abi1, const ojson& abi2, char direction) {
+      unsigned find_types(const ojson& abi1, const ojson& abi2, char direction) {
+         unsigned differences = 0;
          for ( int i=0; i < abi1["types"].size(); i++ ) {
             bool found = false;
             for ( int j=0; j < abi2["types"].size(); j++ ) {
@@ -136,9 +143,12 @@ class abidiff {
                   found = true;
                }
             }
-            if (!found)
+            if (!found) {
+               ++differences;
                print_type(abi1, i, direction);
+            }
          }
+         return differences;
       }
 
       void print_action(const ojson& abi, int index, char direction) {
@@ -146,7 +156,8 @@ class abidiff {
          std::cout << pretty_print(abi["actions"].at(index)) << "\n";
       }
 
-      void find_actions(const ojson& abi1, const ojson& abi2, char direction) {
+      unsigned find_actions(const ojson& abi1, const ojson& abi2, char direction) {
+         unsigned differences = 0;
          for ( int i=0; i < abi1["actions"].size(); i++ ) {
             bool found = false;
             for ( int j=0; j < abi2["actions"].size(); j++ ) {
@@ -156,9 +167,12 @@ class abidiff {
                   found = true;
                }
             }
-            if (!found)
+            if (!found) {
+               ++differences;
                print_action(abi1, i, direction);
+            }
          }
+         return differences;
       }
 
       void print_event(const ojson& abi, int index, char direction) {
@@ -166,7 +180,8 @@ class abidiff {
          std::cout << pretty_print(abi["events"].at(index)) << "\n";
       }
 
-      void find_events(const ojson& abi1, const ojson& abi2, char direction) {
+      unsigned find_events(const ojson& abi1, const ojson& abi2, char direction) {
+         unsigned differences = 0;
          for ( int i=0; i < abi1["events"].size(); i++ ) {
             bool found = false;
             for ( int j=0; j < abi2["events"].size(); j++ ) {
@@ -176,9 +191,12 @@ class abidiff {
                   found = true;
                }
             }
-            if (!found)
+            if (!found) {
+               ++differences;
                print_event(abi1, i, direction);
+            }
          }
+         return differences;
       }
 
       void print_order(const ojson& abi, int index, char direction) {
@@ -191,7 +209,8 @@ class abidiff {
          std::cout << pretty_print(abi["indexes"].at(index)) << "\n";
       }
 
-      void find_indexes(const ojson& abi1, const ojson& abi2, char direction) {
+      unsigned find_indexes(const ojson& abi1, const ojson& abi2, char direction) {
+         unsigned differences = 0;
          for ( int i=0; i < abi1["indexes"].size(); i++ ) {
             bool found = false;
             for ( int j=0; j < abi2["indexes"].size(); j++ ) {
@@ -212,9 +231,12 @@ class abidiff {
                   }
                }
             }
-            if (!found)
+            if (!found) {
+               ++differences;
                print_index(abi1, i, direction);
+            }
          }
+         return differences;
       }
 
       void print_table(const ojson& abi, int index, char direction) {
@@ -222,21 +244,25 @@ class abidiff {
          std::cout << pretty_print(abi["tables"].at(index)) << "\n";
       }
 
-      void find_tables(const ojson& abi1, const ojson& abi2, char direction) {
+      unsigned find_tables(const ojson& abi1, const ojson& abi2, char direction) {
+         unsigned differences = 0;
          for ( int i=0; i < abi1["tables"].size(); i++ ) {
             bool found = false;
             for ( int j=0; j < abi2["tables"].size(); j++ ) {
                if (abi1["tables"].at(i)["name"] == abi2["tables"].at(j)["name"]) {
                   if (abi1["tables"].at(i)["type"] != abi2["tables"].at(j)["type"])
                      break;
-                  find_indexes(abi1["tables"].at(i), abi2["tables"].at(j), '<');
-                  find_indexes(abi2["tables"].at(j), abi1["tables"].at(i), '>');
+                  differences += find_indexes(abi1["tables"].at(i), abi2["tables"].at(j), '<');
+                  differences += find_indexes(abi2["tables"].at(j), abi1["tables"].at(i), '>');
                   found = true;
                }
             }
-            if (!found)
+            if (!found) {
+               ++differences;
                print_table(abi1, i, direction);
+            }
          }
+         return differences;
       }
 
       void print_variant(const ojson& abi, int index, char direction) {
@@ -244,7 +270,8 @@ class abidiff {
          std::cout << pretty_print(abi["variants"].at(index)) << "\n";
       }
 
-      void find_variants(const ojson& abi1, const ojson& abi2, char direction) {
+      unsigned find_variants(const ojson& abi1, const ojson& abi2, char direction) {
+         unsigned differences = 0;
          for ( int i=0; i < abi1["variants"].size(); i++ ) {
             bool found = false;
             for ( int j=0; j < abi2["variants"].size(); j++ ) {
@@ -256,50 +283,55 @@ class abidiff {
                }
 
             }
-            if (!found)
+            if (!found) {
+               ++differences;
                print_variant(abi1, i, direction);
+            }
          }
+         return differences;
       }
 
-      void diff_structs() {
-         find_structs(abi_1, abi_2, '<');
-         find_structs(abi_2, abi_1, '>');
+      unsigned diff_structs() {
+         return find_structs(abi_1, abi_2, '<') +
+                find_structs(abi_2, abi_1, '>');
       }
 
-      void diff_types() {
-         find_types(abi_1, abi_2, '<');
-         find_types(abi_2, abi_1, '>');
+      unsigned diff_types() {
+         return find_types(abi_1, abi_2, '<') +
+                find_types(abi_2, abi_1, '>');
       }
 
-      void diff_actions() {
-         find_actions(abi_1, abi_2, '<');
-         find_actions(abi_2, abi_1, '>');
+      unsigned diff_actions() {
+         return find_actions(abi_1, abi_2, '<') +
+                find_actions(abi_2, abi_1, '>');
       }
 
-      void diff_events() {
-         find_events(abi_1, abi_2, '<');
-         find_events(abi_2, abi_1, '>');
+      unsigned diff_events() {
+         return find_events(abi_1, abi_2, '<') +
+                find_events(abi_2, abi_1, '>');
       }
 
-      void diff_tables() {
-         find_tables(abi_1, abi_2, '<');
-         find_tables(abi_2, abi_1, '>');
+      unsigned diff_tables() {
+         return find_tables(abi_1, abi_2, '<') +
+                find_tables(abi_2, abi_1, '>');
       }
 
-      void diff_variants() {
-         find_variants(abi_1, abi_2, '<');
-         find_variants(abi_2, abi_1, '>');
+      unsigned diff_variants() {
+         return find_variants(abi_1, abi_2, '<') +
+                find_variants(abi_2, abi_1, '>');
       }
 
-      void diff() {
-         diff_version();
-         diff_structs();
-         diff_types();
-         diff_actions();
-         diff_events();
-         diff_tables();
+      unsigned diff() {
+         unsigned differences = 0;
+         differences += diff_version();
+         differences += diff_structs();
+         differences += diff_types();
+         differences += diff_actions();
+         differences += diff_events();
+         differences += diff_tables();
          if ( get_version(abi_1) >= 11 && get_version(abi_2) >= 11 )
-            diff_variants();
+            differences += diff_variants();
+         return differences;
       }
 };
 
@@ -321,14 +353,15 @@ int main(int argc, const char **argv) {
       cl::Required,
       cl::cat(cat));
 
+   unsigned differences;
    cl::ParseCommandLineOptions(argc, argv, std::string("cyberway-abidiff"));
    try {
       abidiff diff(input_filename1, input_filename2);
-      diff.diff();
+      differences = diff.diff();
    } catch ( std::exception& e ) {
       std::cout << e.what() << "\n";
       return -1;
    }
    
-   return 0;
+   return differences == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Resolve #167 

`abidiff` return 1 if If found difference in ABIs. So bash-script (or build system) can easy detect that ABI diffs.