### PR TITLE
Add writting strategy to binary extension. #175

### DIFF
--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -11,15 +11,27 @@ namespace eosio {
     */
 
     /**
+    *  Writing strategy for binary_extension if it doesn't have value
+    *
+    *  @ingroup binary_extension
+    */
+   enum class write_strategy {
+      default_value, ///! If there is no value, write the default value to a data stream
+      no_value ///! If there is no value, don't write a value to a data stream
+   };
+
+    /**
     *  Container to hold a binary payload for an extension
     *
     *  @ingroup binary_extension
     *  @tparam T - Contained typed
+    *  @tparam S - Writing strategy for no value
     */
-   template <typename T>
+   template <typename T,  write_strategy S = write_strategy::default_value>
    class binary_extension {
       public:
          using value_type = T;
+
 
          constexpr binary_extension() {}
          constexpr binary_extension( const T& ext )
@@ -169,7 +181,7 @@ namespace eosio {
    /// @cond IMPLEMENTATIONS
 
    /**
-    *  Serialize a binary_extension into a stream
+    *  Serialize a binary_extension into a stream for write_strategy::default_value
     *
     *  @ingroup binary_extension
     *  @brief Serialize a binary_extension
@@ -179,9 +191,27 @@ namespace eosio {
     *  @return DataStream& - Reference to the datastream
     */
    template<typename DataStream, typename T>
-   inline DataStream& operator<<(DataStream& ds, const eosio::binary_extension<T>& be) {
+   inline DataStream& operator<<(DataStream& ds, const eosio::binary_extension<T, write_strategy::default_value>& be) {
      ds << be.value_or();
      return ds;
+   }
+
+   /**
+    *  Serialize a binary_extension into a stream for write_strategy::no_value
+    *
+    *  @ingroup binary_extension
+    *  @brief Serialize a binary_extension
+    *  @param ds - The stream to write
+    *  @param opt - The value to serialize
+    *  @tparam DataStream - Type of datastream buffer
+    *  @return DataStream& - Reference to the datastream
+    */
+   template<typename DataStream, typename T>
+   inline DataStream& operator<<(DataStream& ds, const eosio::binary_extension<T, write_strategy::no_value>& be) {
+      if (be.has_value()) {
+         ds << be.value();
+      }
+      return ds;
    }
 
    /**
@@ -194,8 +224,8 @@ namespace eosio {
     *  @tparam DataStream - Type of datastream buffer
     *  @return DataStream& - Reference to the datastream
     */
-   template<typename DataStream, typename T>
-   inline DataStream& operator>>(DataStream& ds, eosio::binary_extension<T>& be) {
+   template<typename DataStream, typename T, eosio::write_strategy S>
+   inline DataStream& operator>>(DataStream& ds, eosio::binary_extension<T, S>& be) {
      if( ds.remaining() ) {
         T val;
         ds >> val;


### PR DESCRIPTION
Resolve #175:
- Implement the writing strategy for binary extension
- For compatibility with EOS, default strategy is `default_value`
