### PR TITLE
Binary extension move/copy and singleton. #176

### DIFF
--- a/libraries/eosiolib/contracts/eosio/singleton.hpp
+++ b/libraries/eosiolib/contracts/eosio/singleton.hpp
@@ -113,12 +113,12 @@ namespace  eosio {
           * @param value - New value to be set
           * @param bill_to_account - Account to pay for the new value
           */
-         void set( const T& value, name bill_to_account ) {
+         void set( T value, name bill_to_account ) {
             auto itr = _t.find( pk_value );
             if( itr != _t.end() ) {
-               _t.modify(itr, bill_to_account, [&](row& r) { r.value = value; });
+               _t.modify(itr, bill_to_account, [&](row& r) { r.value = std::move(value); });
             } else {
-               _t.emplace(bill_to_account, [&](row& r) { r.value = value; });
+               _t.emplace(bill_to_account, [&](row& r) { r.value = std::move(value); });
             }
          }
 

--- a/libraries/eosiolib/contracts/eosio/singleton.hpp
+++ b/libraries/eosiolib/contracts/eosio/singleton.hpp
@@ -67,7 +67,7 @@ namespace  eosio {
           * @return true - if exists
           * @return false - otherwise
           */
-         bool exists() {
+         bool exists() const {
             return _t.find( pk_value ) != _t.end();
          }
 
@@ -77,7 +77,7 @@ namespace  eosio {
           * @brief Get the value stored inside the singleton table
           * @return T - The value stored
           */
-         T get() {
+         const T& get() const {
             auto itr = _t.find( pk_value );
             eosio::check( itr != _t.end(), "singleton does not exist" );
             return itr->value;

--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -69,6 +69,29 @@ namespace eosio {
             }
          }
 
+         constexpr binary_extension& operator = (const binary_extension& other) {
+            if (has_value())
+               reset();
+
+            if (other.has_value()) {
+               ::new (&_data) T(*other);
+               _has_value = true;
+            }
+            return *this;
+         }
+
+         constexpr binary_extension& operator = (binary_extension&& other) {
+            if (has_value())
+               reset();
+
+            if (other.has_value()) {
+               ::new (&_data) T(*other);
+               _has_value = true;
+               other._has_value = false;
+            }
+            return *this;
+         }
+
          /** test if container is holding a value */
          constexpr explicit operator bool()const { return _has_value; }
          /** test if container is holding a value */


### PR DESCRIPTION
Resolve #176:
- singleton::set accept copy value instead of const reference, so copy strategy can be implemented in a calling code
- add copy and move operator in binary extension (the same is done in the develop branch of eosio.cdt)
